### PR TITLE
Updated plugin and daemon to support CNI spec 0.3.1

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -77,10 +77,12 @@ func (ib *Infoblox) requestAddress(conf NetConfig, args *ExtCmdArgs, result *cur
 	hwAddr, err := hwaddr.GenerateHardwareAddr4(net.ParseIP(ip), hwaddr.PrivateMACPrefix)
 	if err != nil {
 		log.Printf("Problem while generating hardware address using ip: %s", err)
+		return err
 	}
-	_, err = ib.updateAddress(netviewName, cidr, ip, hwAddr.String())
+	err = ib.updateAddress(netviewName, cidr, ip, hwAddr.String())
 	if err != nil {
 		log.Printf("Problem while updating MacAddress: %s", err)
+		return err
 	}
 	ipn, _ := types.ParseCIDR(cidr)
 	ipn.IP = net.ParseIP(ip)
@@ -97,17 +99,18 @@ func (ib *Infoblox) requestAddress(conf NetConfig, args *ExtCmdArgs, result *cur
 	return nil
 }
 
-func (ib *Infoblox) updateAddress(netviewName string, cidr string, ipAddr string, macAddr string) (string, error) {
+func (ib *Infoblox) updateAddress(netviewName string, cidr string, ipAddr string, macAddr string) error {
 
 	fixedAddr, err := ib.Drv.GetAddress(netviewName, cidr, ipAddr, "")
-	if fixedAddr == nil {
-		return "", err
+	if err != nil {
+		return err
 	}
 	updatedFixedAddr, err := ib.Drv.UpdateAddress(fixedAddr.Ref, macAddr, "")
-	if updatedFixedAddr == nil {
-		return "", err
+	if err != nil {
+		return err
 	}
-	return "", nil
+	log.Printf("UpdatedAddress: fixedAddr result is '%s'", *updatedFixedAddr)
+	return nil
 }
 
 func convertRoutesToCurrent(routes []types.Route) []*types.Route {

--- a/infoblox-ipam.go
+++ b/infoblox-ipam.go
@@ -35,7 +35,7 @@ type IBInfobloxDriver interface {
 	RequestNetworkView(netviewName string) (string, error)
 	RequestAddress(netviewName string, cidr string, ipAddr string, macAddr string, vmID string) (string, error)
 	GetAddress(netviewName string, cidr string, ipAddr string, macAddr string) (*ibclient.FixedAddress, error)
-	UpdateAddress(fixedAddr *ibclient.FixedAddress, macAddr string, vmID string) (string, error)
+	UpdateAddress(fixedAddrRef string, macAddr string, vmID string) (*ibclient.FixedAddress, error)
 	ReleaseAddress(netviewName string, ipAddr string, macAddr string) (ref string, err error)
 	RequestNetwork(netconf NetConfig) (network string, err error)
 }
@@ -64,13 +64,12 @@ func (ibDrv *InfobloxDriver) RequestNetworkView(netviewName string) (string, err
 }
 
 func (ibDrv *InfobloxDriver) GetAddress(netviewName string, cidr string, ipAddr string, macAddr string) (*ibclient.FixedAddress, error) {
-	var fixedAddr *ibclient.FixedAddress
 	if netviewName == "" {
 		netviewName = ibDrv.DefaultNetworkView
 	}
-	fixedAddr, _ = ibDrv.objMgr.GetFixedAddress(netviewName, cidr, ipAddr, macAddr)
+	fixedAddr, err := ibDrv.objMgr.GetFixedAddress(netviewName, cidr, ipAddr, macAddr)
 
-	return fixedAddr, nil
+	return fixedAddr, err
 }
 
 func (ibDrv *InfobloxDriver) RequestAddress(netviewName string, cidr string, ipAddr string, macAddr string, vmID string) (string, error) {
@@ -94,12 +93,12 @@ func (ibDrv *InfobloxDriver) RequestAddress(netviewName string, cidr string, ipA
 	return fmt.Sprintf("%s", fixedAddr.IPAddress), nil
 }
 
-func (ibDrv *InfobloxDriver) UpdateAddress(fixedAddr *ibclient.FixedAddress, macAddr string, vmID string) (string, error) {
+func (ibDrv *InfobloxDriver) UpdateAddress(fixedAddrRef string, macAddr string, vmID string) (*ibclient.FixedAddress, error) {
 
-	fixedAddr, _ = ibDrv.objMgr.UpdateFixedAddress(fixedAddr, macAddr, vmID)
+	fixedAddr, err := ibDrv.objMgr.UpdateFixedAddress(fixedAddrRef, macAddr, vmID)
 
 	log.Printf("UpdateAddress: fixedAddr result is '%s'", *fixedAddr)
-	return fmt.Sprintf("%s", fixedAddr.IPAddress), nil
+	return fixedAddr, err
 }
 
 func (ibDrv *InfobloxDriver) ReleaseAddress(netviewName string, ipAddr string, macAddr string) (ref string, err error) {

--- a/infoblox-ipam.go
+++ b/infoblox-ipam.go
@@ -34,6 +34,7 @@ type Container struct {
 type IBInfobloxDriver interface {
 	RequestNetworkView(netviewName string) (string, error)
 	RequestAddress(netviewName string, cidr string, ipAddr string, macAddr string, vmID string) (string, error)
+	UpdateAddress(netviewName string, cidr string, ipAddr string, macAddr string, vmID string) (string, error)
 	ReleaseAddress(netviewName string, ipAddr string, macAddr string) (ref string, err error)
 	RequestNetwork(netconf NetConfig) (network string, err error)
 }
@@ -80,6 +81,19 @@ func (ibDrv *InfobloxDriver) RequestAddress(netviewName string, cidr string, ipA
 
 	log.Printf("RequestAddress: fixedAddr result is '%s'", *fixedAddr)
 	return fmt.Sprintf("%s", fixedAddr.IPAddress), nil
+}
+
+func (ibDrv *InfobloxDriver) UpdateAddress(netviewName string, cidr string, ipAddr string, macAddr string, vmID string) (string, error) {
+        var fixedAddr *ibclient.FixedAddress
+
+	if netviewName == "" {
+		netviewName = ibDrv.DefaultNetworkView
+	}
+
+        fixedAddr, _ = ibDrv.objMgr.UpdateFixedAddress(netviewName, cidr, ipAddr, macAddr, vmID)
+
+        log.Printf("UpdateAddress: fixedAddr result is '%s'", *fixedAddr)
+        return fmt.Sprintf("%s", fixedAddr.IPAddress), nil
 }
 
 func (ibDrv *InfobloxDriver) ReleaseAddress(netviewName string, ipAddr string, macAddr string) (ref string, err error) {

--- a/infoblox-ipam.go
+++ b/infoblox-ipam.go
@@ -96,8 +96,9 @@ func (ibDrv *InfobloxDriver) RequestAddress(netviewName string, cidr string, ipA
 func (ibDrv *InfobloxDriver) UpdateAddress(fixedAddrRef string, macAddr string, vmID string) (*ibclient.FixedAddress, error) {
 
 	fixedAddr, err := ibDrv.objMgr.UpdateFixedAddress(fixedAddrRef, macAddr, vmID)
-
-	log.Printf("UpdateAddress: fixedAddr result is '%s'", *fixedAddr)
+	if err != nil {
+		log.Printf("UpdateAddress failed with error '%s'", err)
+	}
 	return fixedAddr, err
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -45,6 +45,9 @@ func getMacAddress(netns string, ifaceName string) (mac string) {
 	ifaceInfo := &InterfaceInfo{}
 	if netns == "" {
 		ifaceInfo.iface, err = net.InterfaceByName(ifaceName)
+		if err != nil {
+			return ""
+		}
 		mac = ifaceInfo.iface.HardwareAddr.String()
 
 	} else {


### PR DESCRIPTION
The above changes is verified with openshift and kubernetes cluster
with docker containers.

rkt do not support CNI spec 0.3.1, it will support from rkt release
1.29.0 as per pull request: https://github.com/rkt/rkt/pull/3668
which is expected to be merged in august end.