### PR TITLE
CNI 0.6.0 support and delete ip fixed for bridge

### DIFF
--- a/README-K8S.md
+++ b/README-K8S.md
@@ -36,7 +36,7 @@ kubectl - 1.9.0-00
 kubelet - 1.9.0-00
 kubernetes-cni - 0.6.0-00
 
-CNI source used to build the plugin and daemon - tag v0.5.2
+CNI source used to build the plugin and daemon - 0.6.0
 Wapi version - 2.3
 ```
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"


### PR DESCRIPTION
bridge generates mac address based on ip it gets from ipam driver, so daemon updating the same generated mac to NIOS. Other CNI plugins like macvlan, ipvlan etc don't generate mac and use the already assigned mac.