### PR TITLE
Add name during IP allocation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -25,8 +25,8 @@
 [[projects]]
   name = "github.com/infobloxopen/infoblox-go-client"
   packages = ["."]
-  revision = "eb593614d9cd27423fcb69deac7371a95363318a"
-  version = "v0.4.0"
+  revision = "93fd8a5a8109b0dac5e69b99aee08da91307f263"
+  version = "v0.5.0"
 
 [[projects]]
   name = "github.com/onsi/ginkgo"
@@ -147,6 +147,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "50fafed173631913dad974dd632b24af1353e48add863c0f84d82368dc6aa517"
+  inputs-digest = "627966fee40be80b3058f1c41d136b900628d39e1034d4a33fa3b467c99e7ce6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/infobloxopen/infoblox-go-client"
-  version = "0.4.0"
+  version = "0.5.0"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/rpc"
 	"runtime"
+	"strings"
 
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -44,7 +45,18 @@ func newInfoblox(drv IBInfobloxDriver) *Infoblox {
 // Allocate acquires an IP from Infoblox for a specified container.
 func (ib *Infoblox) Allocate(args *ExtCmdArgs, result *current.Result) (err error) {
 	conf := NetConfig{}
+
 	log.Printf("Allocate: called with args '%s'", *args)
+	/* Sample args passed in K8s
+	ContainerID: 85f177f2f1981087309589281979e1190931a9f3d7840660ac8dd9eaeb5685fb
+	Netns       /proc/2617/ns/net
+	IfName      eth0
+	Args        IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=test-infoblox-deployment-8478849b97-p2jhp;K8S_POD_INFRA_CONTAINER_ID=<>
+	Path        /opt/macvlan/bin:/opt/cni/bin
+	StdinData   {"cniVersion":"","ipam":{"gateway":"10.0.0.1","network-view":"cni_view","subnet":"10.0.0.0/24","type":"infoblox"},"master":"eth1","name":"ipam-test","type":"macvlan"}}
+66:c2:1c:94:6e:e5}
+	 */
+
 	if err = json.Unmarshal(args.StdinData, &conf); err != nil {
 		return fmt.Errorf("error parsing netconf: %v", err)
 	}
@@ -79,8 +91,16 @@ func (ib *Infoblox) Allocate(args *ExtCmdArgs, result *current.Result) (err erro
 
 func (ib *Infoblox) requestAddress(conf NetConfig, args *ExtCmdArgs, result *current.Result, netviewName string, cidr string, macAddr string) (err error) {
 
+	// In Kubernetes to get the container name/hostname
+	containerName := ""
+	str1 := strings.Split(args.Args,"K8S_POD_NAME=")
+	if len(str1) != 1 {
+		str2 := strings.Split(str1[1],";")
+		containerName = str2[0]
+	}
+
 	log.Printf("RequestAddress: '%s', '%s', '%s'", netviewName, cidr, macAddr)
-	ip, _ := ib.Drv.RequestAddress(netviewName, cidr, "", macAddr, args.ContainerID)
+	ip, _ := ib.Drv.RequestAddress(netviewName, cidr, "", macAddr, containerName, args.ContainerID)
 
 	log.Printf("Allocated IP: '%s'", ip)
 
@@ -93,7 +113,7 @@ func (ib *Infoblox) requestAddress(conf NetConfig, args *ExtCmdArgs, result *cur
 			return err
 		}
 
-		err = ib.updateAddress(netviewName, cidr, ip, hwAddr.String())
+		err = ib.updateAddress(netviewName, cidr, ip, hwAddr.String(), containerName)
 		if err != nil {
 			log.Printf("Problem while updating MacAddress: %s", err)
 			return err
@@ -114,13 +134,13 @@ func (ib *Infoblox) requestAddress(conf NetConfig, args *ExtCmdArgs, result *cur
 	return nil
 }
 
-func (ib *Infoblox) updateAddress(netviewName string, cidr string, ipAddr string, macAddr string) error {
+func (ib *Infoblox) updateAddress(netviewName string, cidr string, ipAddr string, macAddr string, name string) error {
 
 	fixedAddr, err := ib.Drv.GetAddress(netviewName, cidr, ipAddr, "")
 	if err != nil {
 		return err
 	}
-	updatedFixedAddr, err := ib.Drv.UpdateAddress(fixedAddr.Ref, macAddr, "")
+	updatedFixedAddr, err := ib.Drv.UpdateAddress(fixedAddr.Ref, macAddr, name, "" )
 	if err != nil {
 		return err
 	}

--- a/infoblox-ipam.go
+++ b/infoblox-ipam.go
@@ -34,9 +34,9 @@ type Container struct {
 
 type IBInfobloxDriver interface {
 	RequestNetworkView(netviewName string) (string, error)
-	RequestAddress(netviewName string, cidr string, ipAddr string, macAddr string, vmID string) (string, error)
+	RequestAddress(netviewName string, cidr string, ipAddr string, macAddr string, name string, vmID string) (string, error)
 	GetAddress(netviewName string, cidr string, ipAddr string, macAddr string) (*ibclient.FixedAddress, error)
-	UpdateAddress(fixedAddrRef string, macAddr string, vmID string) (*ibclient.FixedAddress, error)
+	UpdateAddress(fixedAddrRef string, macAddr string, name string, vmID string) (*ibclient.FixedAddress, error)
 	ReleaseAddress(netviewName string, ipAddr string, macAddr string) (ref string, err error)
 	RequestNetwork(netconf NetConfig, netviewName string) (network string, err error)
 	CreateGateway(cidr string,gw net.IP,netviewName string)(string,error)
@@ -74,7 +74,7 @@ func (ibDrv *InfobloxDriver) GetAddress(netviewName string, cidr string, ipAddr 
 	return fixedAddr, err
 }
 
-func (ibDrv *InfobloxDriver) RequestAddress(netviewName string, cidr string, ipAddr string, macAddr string, vmID string) (string, error) {
+func (ibDrv *InfobloxDriver) RequestAddress(netviewName string, cidr string, ipAddr string, macAddr string, name string, vmID string) (string, error) {
 	var fixedAddr *ibclient.FixedAddress
 	if netviewName == "" {
 		netviewName = ibDrv.DefaultNetworkView
@@ -87,16 +87,16 @@ func (ibDrv *InfobloxDriver) RequestAddress(netviewName string, cidr string, ipA
 	}
 
 	if fixedAddr == nil {
-		fixedAddr, _ = ibDrv.objMgr.AllocateIP(netviewName, cidr, ipAddr, macAddr, vmID)
+		fixedAddr, _ = ibDrv.objMgr.AllocateIP(netviewName, cidr, ipAddr, macAddr, name, vmID)
 	}
 
 	log.Printf("RequestAddress: fixedAddr result is '%s'", *fixedAddr)
 	return fmt.Sprintf("%s", fixedAddr.IPAddress), nil
 }
 
-func (ibDrv *InfobloxDriver) UpdateAddress(fixedAddrRef string, macAddr string, vmID string) (*ibclient.FixedAddress, error) {
+func (ibDrv *InfobloxDriver) UpdateAddress(fixedAddrRef string, macAddr string, name string, vmID string) (*ibclient.FixedAddress, error) {
 
-	fixedAddr, err := ibDrv.objMgr.UpdateFixedAddress(fixedAddrRef, macAddr, vmID)
+	fixedAddr, err := ibDrv.objMgr.UpdateFixedAddress(fixedAddrRef, macAddr, name, vmID)
 	if err != nil {
 		log.Printf("UpdateAddress failed with error '%s'", err)
 	}
@@ -270,7 +270,7 @@ func (ibDrv *InfobloxDriver)CreateGateway(cidr string,gw net.IP,netviewName stri
 	if err == nil && gatewayIp != nil {
 		log.Println("The Gateway already created")
 	} else if gatewayIp == nil {
-		gatewayIp, err = ibDrv.objMgr.AllocateIP(netviewName, cidr, gateway, "", "")
+		gatewayIp, err = ibDrv.objMgr.AllocateIP(netviewName, cidr, gateway, "", "", "")
 		if err != nil {
 			log.Printf("Gateway creation failed with error:'%s'", err)
 		}


### PR DESCRIPTION
Presently while allocating a ip address to a container name is
not considered. This patch is capable of including the name of
container during IP allocation and updation request.